### PR TITLE
(fix) Don't panic on resize down

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -319,6 +319,7 @@ impl<T> Grid<T> {
     fn shrink_lines(&mut self, lines: index::Line) {
         while index::Line(self.raw.len()) != lines {
             self.raw.pop_back();
+            let _ = self.move_visible_region_up(AbsoluteLine(1));
         }
 
         self.lines = lines;


### PR DESCRIPTION
I did some digging into why the panic was happening, and discovered that the `grid.visible_region_start` wasn't being updated after resizing to a smaller window.

Unfortunately, the scrollback is truncated after resize now, but the good news is no crashes.