### PR TITLE
Fix out of bounds error when Alacritty windows are resized.

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -596,9 +596,13 @@ impl<T> Grid<T> {
         &self.raw[self.absolute_to_raw_index(line)]
     }
 
-    pub fn get_visible_line(&self, line: Line) -> &Row<T> {
+    pub fn get_visible_line(&self, line: Line) -> Option<&Row<T>> {
         let idx = self.absolute_to_raw_index(self.visible_region_start + line.to_absolute());
-        &self.raw[idx]
+        if idx < self.lines.0 {
+            Some(&self.raw[idx])
+        } else {
+            None
+        }
     }
 
     /// Enable or disable scrollback temporarily

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -333,7 +333,12 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
                 // Grab current state for this iteration
                 let line = self.line;
                 let column = self.column;
-                let cell = &self.grid.get_visible_line(self.line)[column];
+
+                let visible_line = self.grid.get_visible_line(self.line);
+                let cell = match visible_line {
+                    None => { self.column += 1; continue },
+                    Some(visible) => &visible[column],
+                };
 
                 let index = Linear(self.grid.visible_to_absolute_line(line).0 * self.grid.num_cols().0 + column.0);
                 let mut cursor_cell = false;


### PR DESCRIPTION
This fixes an error when Alacritty crashes due to an out of bounds error:

```
alacritty git:(master) ✗ RUST_BACKTRACE=1 ./target/debug/alacritty
[unhandled osc_dispatch]: [['1','0',],['?',],] at line 784
[unhandled osc_dispatch]: [['1','1',],['?',],] at line 797
thread 'main' panicked at 'Out of bounds access', src/libcore/option.rs:839:4
stack backtrace:
   0: std::sys::imp::backtrace::tracing::imp::unwind_backtrace
   1: std::sys_common::backtrace::print
   2: std::panicking::default_hook::{{closure}}
   3: std::panicking::default_hook
   4: std::panicking::rust_panic_with_hook
   5: std::panicking::begin_panic
   6: std::panicking::begin_panic_fmt
   7: rust_begin_unwind
   8: core::panicking::panic_fmt
   9: core::option::expect_failed
  10: <core::option::Option<T>>::expect
             at /build/rust/src/rustc-1.22.1-src/src/libcore/option.rs:302
  11: <alloc::vec_deque::VecDeque<A> as core::ops::index::Index<usize>>::index
             at /build/rust/src/rustc-1.22.1-src/src/liballoc/vec_deque.rs:2365
  12: <alacritty::grid::Grid<T>>::get_visible_line
             at src/grid.rs:601
  13: <alacritty::term::RenderableCellsIter<'a> as core::iter::iterator::Iterator>::next
             at src/term/mod.rs:336
  14: alacritty::renderer::RenderApi::render_cells
             at src/renderer/mod.rs:827
  15: alacritty::display::Display::draw::{{closure}}
             at src/display.rs:364
  16: alacritty::renderer::QuadRenderer::with_api
             at src/renderer/mod.rs:658
  17: alacritty::display::Display::draw
             at src/display.rs:357
  18: alacritty::run
             at src/main.rs:202
  19: alacritty::main
             at src/main.rs:53
  20: __rust_maybe_catch_panic
  21: std::panicking::try
  22: std::rt::lang_start
  23: main
  24: __libc_start_main
  25: _start
thread 'pty reader' panicked at 'called `Result::unwrap()` on an `Err` value: EventsLoopClosed', src/libcore/result.rs:906:4
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
stack backtrace:
   0: std::sys::imp::backtrace::tracing::imp::unwind_backtrace
   1: std::sys_common::backtrace::print
   2: std::panicking::default_hook::{{closure}}
   3: std::panicking::default_hook
   4: std::panicking::rust_panic_with_hook
   5: std::panicking::begin_panic
   6: std::panicking::begin_panic_fmt
   7: rust_begin_unwind
   8: core::panicking::panic_fmt
   9: core::result::unwrap_failed
➜  alacritty git:(master) ✗
```