### PR TITLE
Fix failing ref tests

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -140,7 +140,7 @@ pub struct Grid<T> {
     visible_region_start: index::AbsoluteLine,
 
     /// Scrollback config, ie: is it enabled, if so, how many lines
-    pub scrollback: ScrollbackState,
+    scrollback: ScrollbackState,
 }
 
 pub struct GridIterator<'a, T: 'a> {

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -141,7 +141,7 @@ pub struct Grid<T> {
     visible_region_start: index::AbsoluteLine,
 
     /// Scrollback config, ie: is it enabled, if so, how many lines
-    pub scrollback: ScrollbackState,
+    scrollback: ScrollbackState,
 }
 
 pub struct GridIterator<'a, T: 'a> {

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -83,7 +83,7 @@ pub enum Scrollback {
 
 // Internal struct used to keep track of scrollback state.
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
-pub struct ScrollbackState {
+struct ScrollbackState {
     // Whether scrollback is enabled at all.. When disabled,
     // `max_lines` will be kept in sync with `lines` in the grid.
     enabled: bool,
@@ -92,7 +92,7 @@ pub struct ScrollbackState {
     // Maximum number of lines in the total scrollback buffer.
     // Once this limit is reached, oldest elements will begin to be
     // removed from the `VecDeque` using `pop_front`
-    pub max_lines: index::AbsoluteLine
+    max_lines: index::AbsoluteLine
 }
 
 impl ScrollbackState {
@@ -502,13 +502,18 @@ impl<T> Grid<T> {
     }
 
     /// Enable or disable scrollback temporarily
-    pub fn set_scrollback_enabled(&mut self, enabled: bool) {
+    pub fn set_scrollback_currently_enabled(&mut self, enabled: bool) {
         self.scrollback.currently_enabled = self.scrollback.enabled && enabled;
     }
 
-    /// Check whether scrollback is enabled
-    pub fn get_scrollback_enabled(&self) -> bool {
+    /// Check whether scrollback is currently enabled
+    pub fn scrollback_currently_enabled(&self) -> bool {
         self.scrollback.currently_enabled
+    }
+
+    /// Check whether scrollback is enabled
+    pub fn scrollback_enabled(&self) -> bool {
+        self.scrollback.enabled
     }
 }
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1189,7 +1189,7 @@ impl Term {
     /// In other words, this is scrolling :D
     pub fn move_visible_region_up(&mut self, lines: AbsoluteLine) {
         // Don't scroll when scrolling is disabled
-        if !self.grid.get_scrollback_enabled() { return; }
+        if !self.grid.scrollback_currently_enabled() { return; }
         match self.grid.move_visible_region_up(lines) {
             Ok(()) => { self.dirty = true; trace!("move_visible_region_down: {}..{} of {}", self.grid.visible_region().start.0, self.grid.visible_region().end.0, self.grid.num_absolute_lines().0); },
             Err(e) => trace!("move_visible_region_up: {:?}", e)
@@ -1198,7 +1198,7 @@ impl Term {
 
     pub fn move_visible_region_down(&mut self, lines: AbsoluteLine) {
         // Don't scroll when scrolling is disabled
-        if !self.grid.get_scrollback_enabled() { return; }
+        if !self.grid.scrollback_currently_enabled() { return; }
         match self.grid.move_visible_region_down(lines) {
             Ok(()) => { self.dirty = true; trace!("move_visible_region_down: {}..{} of {}", self.grid.visible_region().start.0, self.grid.visible_region().end.0, self.grid.num_absolute_lines().0); },
             Err(e) => trace!("move_visible_region_down: {:?}", e)
@@ -1852,7 +1852,7 @@ impl ansi::Handler for Term {
                 self.save_cursor_position();
 
                 // Disable scrolling in the alternate buffer
-                self.grid.set_scrollback_enabled(false);
+                self.grid.set_scrollback_currently_enabled(false);
             },
             ansi::Mode::ShowCursor => self.mode.insert(mode::SHOW_CURSOR),
             ansi::Mode::CursorKeys => self.mode.insert(mode::APP_CURSOR),
@@ -1884,7 +1884,7 @@ impl ansi::Handler for Term {
                 self.restore_cursor_position();
 
                 // Enable scrolling in the normal buffer
-                self.grid.set_scrollback_enabled(true);
+                self.grid.set_scrollback_currently_enabled(true);
             },
             ansi::Mode::ShowCursor => self.mode.remove(mode::SHOW_CURSOR),
             ansi::Mode::CursorKeys => self.mode.remove(mode::APP_CURSOR),

--- a/tests/ref.rs
+++ b/tests/ref.rs
@@ -83,7 +83,7 @@ fn ref_test(dir: &Path) {
 
     let mut config = Config::default();
     // Disable scrollback if the ref test has it disabled
-    if !grid.get_scrollback_enabled() {
+    if !grid.scrollback_enabled() {
         config.disable_scrollback();
     }
 


### PR DESCRIPTION
The ref tests were failing because the `get_scrollback_enabled` method
was checking for currently enabled scrollback, not absolutely enabled
scrollback. This has been fixed by introducing a separate method for
checking if it's enabled.

To prevent this issue in the future the `get_scrollback_enabled` has
also been renamed to `scrollback_currently_enabled` to make clear what
is actually being tested.

There were also a few public statements sprinkled around that were not
necessary, those have been removed.